### PR TITLE
fix mlr3 yhat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Depends:
 License: GPL
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Imports: 
   reticulate,
   ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ DALEXtra 0.2.1
 * Removed h2o::init() from explain_h2o()
 * Removed mljar support as mljar package is not available for R 3.6.2
 * Ajusted to DALEX 1.0
+* fixed `yhat.LearnerClassif()` returning wrong column of probabilities 
 
 DALEXtra 0.2.0
 ----------------------------------------------------------------

--- a/R/yhat.R
+++ b/R/yhat.R
@@ -114,6 +114,10 @@ yhat.LearnerRegr <- function(X.model, newdata, ...) {
 #' @rdname yhat
 #' @export
 yhat.LearnerClassif <- function(X.model, newdata, ...) {
-  predict(X.model, newdata = newdata, predict_type = "prob", ...)[,1]
+  pred <- X.model$predict_newdata(newdata)
+  
+  # return probabilities for class: 1
+  prob <- pred$prob
+  response <- prob[,2]
+  response
 }
-


### PR DESCRIPTION
Now works as intended:
```
# load packages and data
library(mlr3)
library(mlr3learners)
library(DALEXtra)
library(modelStudio)

data <- DALEX::titanic_imputed

# split the data 
index <- sample(1:nrow(data), 0.8*nrow(data))
train <- data[index, ]
test <- data[-index, ]

# mlr ClassifTask takes target as factor
train$survived <- as.factor(train$survived)

# prepare the model
task <- TaskClassif$new(id = "titanic",
                        backend = train,
                        target = "survived")

learner <- lrn("classif.ranger",
               predict_type = "prob")

learner$train(task)

# create an explainer for the model
explainer <- explain_mlr3(learner,
                          data = test,
                          y = test$survived,
                          label = "mlr3")

DALEX::model_performance(explainer)
```