### PR TITLE
pass unmatched arguments in predict_lime_surrogate to lime::explain

### DIFF
--- a/R/predict_surrogate.R
+++ b/R/predict_surrogate.R
@@ -77,7 +77,8 @@ predict_surrogate_lime <- function(explainer, new_observation, n_features = 4, n
   lime_expl <- lime::explain(x = new_observation,
                              explainer = lime_model,
                              n_features = n_features,
-                             n_permutations = n_permutations)
+                             n_permutations = n_permutations,
+                             ...)
   class(lime_expl) <- c("predict_surrogate_lime", class(lime_expl))
   lime_expl
 }


### PR DESCRIPTION
Currently, `predict_surrogate_lime` takes `...` (and inherits the dots from calls to `predict_surrogate` as well), but then does nothing with unmatched arguments. I propose unmatched arguments passed (via `predict_surrogate` or otherwise) to `predict_surroagte_lime` be passed along to `lime::explain`.

This allows me to add something like `dist_fun = "euclidean"` to my `predict_surrogate` call, which speeds things up by ~7x in my particular use case.